### PR TITLE
[FIX] Use `NSDecimalNumber` to format decimals as `String`s

### DIFF
--- a/Examples/CocoaPods/Tests/ZkSignerTests.swift
+++ b/Examples/CocoaPods/Tests/ZkSignerTests.swift
@@ -64,4 +64,11 @@ class ZkSignerTests: XCTestCase {
         XCTAssertEqual(signer.publicKeyHash,
                        ZkSignerTests.PubKeyHash)
     }
+    
+    func testFormatOfDecimalWith18digitsOfPrecision() throws {
+        let decimal = Decimal(string: "0.008756000723707975")!
+        
+        XCTAssertEqual(Utils.format(decimal),
+                       "0.008756000723707975")
+    }
 }

--- a/Sources/ZKSync/Signer/Utils/Utils.swift
+++ b/Sources/ZKSync/Signer/Utils/Utils.swift
@@ -224,7 +224,7 @@ public struct Utils {
     }
 
     public static func format(_ value: Decimal) -> String {
-        return Utils.Formatter.string(from: value as NSDecimalNumber)!
+        return (value as NSDecimalNumber).description(withLocale: Locale(identifier: "en_US_POSIX"))
     }
 
     public static func currentTimeMillis() -> Int64 {


### PR DESCRIPTION
`NSDecimalFormatter` doesn't support decimal numbers with more than 17 digits of precision so numbers with 18 digits are rounded.

One simple example, if we take a decimal like `0.008756000723707975` when using the formatter to convert it to a `String` the output is `"0.00875600072370798"` which means there was a rounding procedure before the actual number was converted into a string.

`NSDecimalNumber` provides a method to convert a decimal number to a string in respect to a certain locale, `description(withLocale:)`,  and that represents the best workaround to convert decimals with a high level of precision into strings.